### PR TITLE
revert: "ci: add python 3.12 (#33)"

### DIFF
--- a/.github/workflows/psr-ci.yml
+++ b/.github/workflows/psr-ci.yml
@@ -72,7 +72,6 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12"
         os:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This reverts commit 9e0e2018c9b3af8196c66c6aa8e2aaaca687cbef.

aiohttp does not yet support Python 3.12.